### PR TITLE
Restart vault when db recovers.

### DIFF
--- a/tools/env/docker-compose.yml
+++ b/tools/env/docker-compose.yml
@@ -40,12 +40,13 @@ services:
       FAV_AGENCY_HOST: 'core'
     ports:
       - '8085:8085'
+    restart: unless-stopped
     entrypoint: >
       /bin/sh -c "
         while ! nc -z vault-db 5432;
         do
           echo 'wait for db';
-          sleep 5;
+          sleep 1;
         done;
         /start.sh;
       "


### PR DESCRIPTION
It seems that when the db container has been stopped and is restarted, it is started in recovery mode in which the server port is already open, but the db cannot be connected to. This causes vault to panic occasionally. Added a restart-flag to vault's docker-compose definition that vault should always restart when this error happens.